### PR TITLE
Avoid writing contents of :ref to the DOM

### DIFF
--- a/src/dumdom/element.cljc
+++ b/src/dumdom/element.cljc
@@ -178,7 +178,7 @@
                    (select-keys attr-mappings)
                    (set/rename-keys attrs))]
     (cond-> {:attrs (apply dissoc attrs :style :mounted-style :leaving-style :disappearing-style
-                           :component :value :key :dangerouslySetInnerHTML event-keys)
+                           :component :value :key :ref :dangerouslySetInnerHTML event-keys)
              :props (merge (select-keys attrs [:value])
                            (when-let [html (-> attrs :dangerouslySetInnerHTML :__html)]
                              {:innerHTML html}))


### PR DESCRIPTION
Currently, if you use a :ref, the DOM element will end up with a toString-ed version of the function you pass to :ref.