### PR TITLE
Make sure style attributes are strings

### DIFF
--- a/src/dumdom/element.cljc
+++ b/src/dumdom/element.cljc
@@ -43,12 +43,13 @@
    (mapcat (fn [k] [k (camel-key k)]))
    set))
 
-(defn- pixelize [styles]
+(defn- normalize-styles [styles]
   (reduce (fn [m [attr v]]
-            (cond-> m
-              (and (number? v)
-                   (not (skip-pixelize-attrs attr)))
-              (update attr str "px")))
+            (if (number? v)
+              (if (skip-pixelize-attrs attr)
+                (update m attr str)
+                (update m attr str "px"))
+              m))
           styles
           styles))
 
@@ -189,13 +190,13 @@
              :props (merge (select-keys attrs [:value])
                            (when-let [html (-> attrs :dangerouslySetInnerHTML :__html)]
                              {:innerHTML html}))
-             :style (merge (pixelize (:style attrs))
+             :style (merge (normalize-styles (:style attrs))
                            (when-let [enter (:mounted-style attrs)]
-                             {:delayed (pixelize enter)})
+                             {:delayed (normalize-styles enter)})
                            (when-let [remove (:leaving-style attrs)]
-                             {:remove (pixelize remove)})
+                             {:remove (normalize-styles remove)})
                            (when-let [destroy (:disappearing-style attrs)]
-                             {:destroy (pixelize destroy)}))
+                             {:destroy (normalize-styles destroy)}))
              :on (->> event-keys
                       (mapv #(event-entry attrs %))
                       (into {}))

--- a/test/dumdom/dom_test.cljs
+++ b/test/dumdom/dom_test.cljs
@@ -15,7 +15,7 @@
            (render-str (d/div {:className "test"} (d/div {:id "yap"} "Hello"))))))
 
   (testing "Renders CSS number values as pixel values"
-    (is (= "<div style=\"width: 100px; right: 30px; top: 20px; height: 50px; margin: 20px; padding: 50px; position: absolute; bottom: 40px; flex: 1; left: 10px\">Hello</div>"
+    (is (= "<div style=\"width: 100px; right: 30px; top: 20px; height: 50px; margin: 20px; padding: 50px; position: absolute; bottom: 40px; flex: 1; opacity: 0; left: 10px\">Hello</div>"
            (render-str (d/div {:style {:width 100
                                        :height 50
                                        :position "absolute"
@@ -25,6 +25,7 @@
                                        :bottom 40
                                        :padding 50
                                        :margin 20
+                                       :opacity 0
                                        :flex 1}} "Hello")))))
 
   (testing "Pixelizes snake-cased and camelCased CSS properties"


### PR DESCRIPTION
This works around a weird bug in Snabbdom when a style is set to 0, and has the
added advantage of being the expected datatype for style attributes.