### PR TITLE
Update comment in event-handler

### DIFF
--- a/src/dumdom/element.cljc
+++ b/src/dumdom/element.cljc
@@ -11,9 +11,6 @@
       ;; At this point we need to "early" bind the late bound var. It made it
       ;; this far, but now it must be frozen in time, so it sticks around for
       ;; the asynchronous events it will handle after being rendered to the DOM.
-      ;;
-      ;; If this isn't a function _nothing_ will happen. Future versions of
-      ;; dumdom should optionally log a warning when that happens.
       (fn [e]
         (f e h)))))
 


### PR DESCRIPTION
`render` now throws exception if `*handle-event*` is not a function