### PR TITLE
Add clj-kondo hook and config for linting `defcomponent`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -181,6 +181,19 @@ would `devcards.core`:
   (my-dumdom-component {:value 0}))
 ```
 
+## Linting
+
+This library exports
+[clj-kondo configuration](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#importing)
+for linting the `defcomponent` macro. You may need to import the config. If you
+are using clojure-lsp, this should happen automatically.
+
+If you are not using clj-kondo, you could get away with using a `defcomponent`
+macro that supports linting as `defn`. Like
+[this one](https://gist.github.com/PEZ/357df3589dc49e83e49da77cb8943723). It
+won't help you spot errors with using the wrong dumdom component options,
+but at least will silence false positive warnings.
+
 ## Contribute
 
 Feel free to report bugs and, even better, provide bug fixing pull requests!

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src"]
+{:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/clojurescript {:mvn/version "1.10.866"}}
  :aliases {:dev {:extra-paths ["dev" "test" "resources"]

--- a/resources/clj-kondo.exports/cjohansen/dumdom/config.edn
+++ b/resources/clj-kondo.exports/cjohansen/dumdom/config.edn
@@ -1,0 +1,2 @@
+{:linters {:dumdom/component-options {:level :warning}}
+ :hooks {:analyze-call {dumdom.core/defcomponent dumdom.defcomponent/defcomponent}}}

--- a/resources/clj-kondo.exports/cjohansen/dumdom/dumdom/defcomponent.clj
+++ b/resources/clj-kondo.exports/cjohansen/dumdom/dumdom/defcomponent.clj
@@ -1,0 +1,69 @@
+(comment ; add-libs
+  '{:deps {clj-kondo/clj-kondo {:mvn/version "2024.02.12"}}})
+
+(ns dumdom.defcomponent
+  (:require [clj-kondo.hooks-api :as api]))
+
+(def valid-opts #{:on-mount
+                  :on-update
+                  :on-render
+                  :on-unmount
+                  :will-appear
+                  :did-appear
+                  :will-enter
+                  :did-enter
+                  :will-leave
+                  :did-leave
+                  :name})
+
+(defn- extract-docstr
+  [[docstr? & forms :as remaining-forms]]
+  (if (api/string-node? docstr?)
+    [docstr? forms]
+    [(api/string-node "no docs") remaining-forms]))
+
+(defn- extract-opts
+  ([forms]
+   (extract-opts forms []))
+  ([[k v & forms :as remaining-forms] opts]
+   (if (api/keyword-node? k)
+     (do
+       (when-not (valid-opts (api/sexpr k))
+         (api/reg-finding! (assoc (meta k)
+                                  :message (str "Invalid option: `" k "`")
+                                  :type :dumdom/component-options)))
+       (extract-opts forms (into opts [k v])))
+     [(api/map-node opts) remaining-forms])))
+
+(defn ^:export defcomponent [{:keys [node]}]
+  (let [[name & forms] (rest (:children node))
+        [docstr forms] (extract-docstr forms)
+        [opts forms] (extract-opts forms)
+        new-node (api/list-node
+                  (list*
+                   (api/token-node 'defn)
+                   name
+                   docstr
+                   opts
+                   forms))]
+    {:node new-node}))
+
+(comment
+  (def code (str '(defcomponent heading
+                    ""
+                    :on-render (fn [dom-node val old-val])
+                    :invalid (fn [])
+                    [data]
+                    (def data data)
+                    [:h2 {:style {:background :black
+                                  :color :white}}
+                     (pr-str (:text data))])))
+
+  (defcomponent {:node (api/parse-string code)})
+
+  (require '[clj-kondo.core :as clj-kondo])
+  (:findings (with-in-str (str "(require '[dumdom.core :refer [defcomponent]])"
+                               " "
+                               code)
+               (clj-kondo/run! {:lint ["-"]})))
+  :rcf)


### PR DESCRIPTION
Hej! Thanks for providing Dumdom! I am having a blast with it.

This PR adds configuration for linting the `defcomponent` macro with clj-kondo. clj-kondo will, upon request, import it and. For people using cljure-lsp, clj-kondo will be requested to do so, and basically thet will not need to do anything but commit the config to their repositories.

In my work project we're currently using an adapted `defcomponent` macro which lends itself to being linted as `defn`. The config submitted here improves on that solution by not requiring Dumdom users to include such a macro, offering some help with getting the life-cycle hook keywords right, and generally is less confusing.

It's my first clj-kondo hook and I'm a bit wary that I'm doing something stupid (I often do!), but things behaves nicely with every test I throw at it.

I'm planning to write some more hooks for event code navigation and checking, but I think those will be better served as examples, because they will depend on what particular framework people set up with the global event handle. At least I think it will depend on that, I guess I will know better once I've started working on the hooks.